### PR TITLE
tiny fix, to accomodate dplyr 1.0.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^CODE_OF_CONDUCT\.md$
 ^\.travis\.yml$
 ^codecov\.yml$
+coverage.xml

--- a/R/tidy_scrap.R
+++ b/R/tidy_scrap.R
@@ -55,10 +55,8 @@ tidy_scrap <- function(link, nodes, colnames, clean = FALSE, askRobot = FALSE){
   allframes <- lapply(nodes, function(x) scrap(link, x))
 
   result <- do.call(cbind,allframes)
-
+  colnames(result) <- colnames
   result <- as_tibble(result)
-
-  names(result) <- colnames
 
   if (!clean) return(result)
 
@@ -70,10 +68,6 @@ tidy_scrap <- function(link, nodes, colnames, clean = FALSE, askRobot = FALSE){
     return(result_clean)
 
   }
-
-
-
-
 
 }
 


### PR DESCRIPTION
This is a very minor fix, as we identified `ralger` as a package that potentially the next release of dplyr (1.0.2) breaks. 

```
[master] 241.7 MiB ❯ revdepcheck::cloud_details(, "ralger")
══ Reverse dependency check ════════════════════════════════════ ralger 2.0.1 ══

Status: BROKEN

── Still failing

✖ checking dependencies in R code ... NOTE

── Newly failing

✖ checking tests ... ERROR

── Before ──────────────────────────────────────────────────────────────────────
❯ checking dependencies in R code ... NOTE
  Namespace in Imports field not imported from: ‘testthat’
    All declared Imports should be used.

0 errors ✔ | 0 warnings ✔ | 1 note ✖

── After ───────────────────────────────────────────────────────────────────────
❯ checking tests ... ERROR
  See below...

❯ checking dependencies in R code ... NOTE
  Namespace in Imports field not imported from: ‘testthat’
    All declared Imports should be used.

── Test failures ───────────────────────────────────────────────── testthat ────

> library(testthat)
> library(ralger)
>
> test_check("ralger")
── 1. Failure: scrap() function (@test-scrap.R#4)  ─────────────────────────────
scrap(link = "https://www.imdb.com/chart/top/", node = ".titleColumn a") not equal to unlist(...).
2/250 mismatches
x[213]: "The Wages of Fear"
y[213]: "Dead Poets Society"

x[214]: "Dead Poets Society"
y[214]: "The Wages of Fear"

── 2. Failure: tidy_scrap() function (@test-tidy_scrap.R#3)  ───────────────────
tidy_scrap(...) not equal to `%>%`(...).
Component "value": 2 string mismatches

══ testthat results  ═══════════════════════════════════════════════════════════
[ OK: 2 | SKIPPED: 0 | WARNINGS: 1 | FAILED: 2 ]
1. Failure: scrap() function (@test-scrap.R#4)
2. Failure: tidy_scrap() function (@test-tidy_scrap.R#3)

Error: testthat unit tests failed
Execution halted
```

I could not reproduce the first problem, so I guess you already did, and here is a fix for the second one. 